### PR TITLE
Allows multiple creators

### DIFF
--- a/src/components/CreatorInfo.js
+++ b/src/components/CreatorInfo.js
@@ -1,0 +1,10 @@
+
+function CreatorInfo(props) {
+  return (
+    <a target='_blank' href={props.link} rel='noreferrer' className='font-bold'>
+      {props.name}
+    </a>
+  )
+}
+
+export default CreatorInfo

--- a/src/components/ModelInfo.js
+++ b/src/components/ModelInfo.js
@@ -59,8 +59,6 @@ const ModelInfo = (model) => {
     },
   ]
 
-  console.log(model.creator)
-
   return (
     <div className='mt-5'>
       <div className='z-10 hidden mb-6 sm:block w-[70%]'>

--- a/src/components/ModelInfo.js
+++ b/src/components/ModelInfo.js
@@ -11,6 +11,17 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(' ')
 }
 
+function Creator(props) {
+
+  console.log("creator ", props)
+
+  return (
+    <a target='_blank' href={props.link} rel='noreferrer' className='font-bold'>
+      {props.name}
+    </a>
+  )
+}
+
 const ModelInfo = (model) => {
   const [tab, setTab] = useState('r3f')
   const { parsedBuffer, createModelDownloadZip } = useStore((s) => ({
@@ -48,21 +59,24 @@ const ModelInfo = (model) => {
     },
   ]
 
+  console.log(model.creator)
+
   return (
     <div className='mt-5'>
       <div className='z-10 hidden mb-6 sm:block w-[70%]'>
         <Leva fill />
       </div>
       <aside className='relative'>
-        <span className='text-gray-600'>Created by: </span>
-        <a
-          target='_blank'
-          href={model.creator.link}
-          rel='noreferrer'
-          className='font-bold'
-        >
-          {model.creator.name}
-        </a>
+
+        <div>
+          <span className='text-gray-600'>Created by: </span>
+          {Array.isArray(model.creator) ? (<ul>
+            {model.creator.map((creator, i) => <li key={i}><Creator {...creator} /></li>)}
+            </ul>) : (
+            <Creator {...model.creator} />
+          )}
+        </div>
+
         {model.team && (
           <div>
             <span className='text-gray-600'>Team: </span>
@@ -76,6 +90,7 @@ const ModelInfo = (model) => {
             </a>
           </div>
         )}
+        
         <span className='block'>
           <span className='text-gray-600'>License: </span>{' '}
           {licenses[model.license] ? (

--- a/src/components/ModelInfo.js
+++ b/src/components/ModelInfo.js
@@ -1,25 +1,19 @@
-import copy from 'clipboard-copy'
-import useStore from '@/helpers/store'
-import parse from '@react-three/gltfjsx'
-import { licenses } from '../helpers/constants/licenses'
-import Tippy from '@tippyjs/react'
 import { useState } from 'react'
-import { API_ENDPOINT } from '@/helpers/constants/api'
+
+import copy from 'clipboard-copy'
+import parse from '@react-three/gltfjsx'
+import Tippy from '@tippyjs/react'
+
 import { Leva } from 'leva'
+
+import useStore from '@/helpers/store'
+import { licenses } from '@/helpers/constants/licenses'
+import { API_ENDPOINT } from '@/helpers/constants/api'
+
+import CreatorInfo from './CreatorInfo'
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ')
-}
-
-function Creator(props) {
-
-  console.log("creator ", props)
-
-  return (
-    <a target='_blank' href={props.link} rel='noreferrer' className='font-bold'>
-      {props.name}
-    </a>
-  )
 }
 
 const ModelInfo = (model) => {
@@ -65,13 +59,19 @@ const ModelInfo = (model) => {
         <Leva fill />
       </div>
       <aside className='relative'>
-
         <div>
           <span className='text-gray-600'>Created by: </span>
-          {Array.isArray(model.creator) ? (<ul>
-            {model.creator.map((creator, i) => <li key={i}><Creator {...creator} /></li>)}
-            </ul>) : (
-            <Creator {...model.creator} />
+          {Array.isArray(model.creator) ? (
+            <ul>
+              {model.creator.map((creator, i) => (
+                <>
+                  <CreatorInfo {...creator} />
+                  {i < model.creator.length - 1 && ', '}
+                </>
+              ))}
+            </ul>
+          ) : (
+            <CreatorInfo {...model.creator} />
           )}
         </div>
 
@@ -88,7 +88,7 @@ const ModelInfo = (model) => {
             </a>
           </div>
         )}
-        
+
         <span className='block'>
           <span className='text-gray-600'>License: </span>{' '}
           {licenses[model.license] ? (

--- a/src/helpers/constants/api.js
+++ b/src/helpers/constants/api.js
@@ -1,2 +1,2 @@
-// export const API_ENDPOINT = 'https://api.market.pmnd.rs'
-export const API_ENDPOINT = 'http://localhost:3001'
+export const API_ENDPOINT = 'https://api.market.pmnd.rs'
+// export const API_ENDPOINT = 'http://localhost:3001'

--- a/src/helpers/constants/api.js
+++ b/src/helpers/constants/api.js
@@ -1,2 +1,2 @@
-export const API_ENDPOINT = 'https://api.market.pmnd.rs'
-// export const API_ENDPOINT = 'http://localhost:3001'
+// export const API_ENDPOINT = 'https://api.market.pmnd.rs'
+export const API_ENDPOINT = 'http://localhost:3001'


### PR DESCRIPTION
This allows multiple creators by just using an array - with objects of the same shape as the regular creator. 

eg.
```json
{
  "name": "Bunny",
  "creator": [{
    "name": "McGuire Computer Graphics Archive",
    "link": "https://casual-effects.com/g3d/data10/index.html#"
  }, {
    "name": "McGuire Computer Graphics Archive",
    "link": "https://casual-effects.com/g3d/data10/index.html#"
  }],
  "license": 1,
  "category": "animals"
}

```

![image](https://user-images.githubusercontent.com/1862172/118164397-5ce07100-b423-11eb-8cfe-fdffa265d7a0.png)
