### PR TITLE
make lint command windows compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": false,
   "scripts": {
     "lint": "yarn prettier && yarn eslint",
-    "eslint": "eslint --fix 'src/**/*.{js,jsx}' --ext jsconfig.json",
+    "eslint": "eslint --fix \"src/**/*.{js,jsx}\" --ext jsconfig.json",
     "prettier": "prettier --list-different '**/*.{js,jsx,md}'",
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
I noticed that this repo is using the react-three-next config 

We've just updated it since I couldn't run the lint on windows/
https://github.com/pmndrs/react-three-next/pull/34 

So I'm making this MR so the fix is also available here.