### PR TITLE
Add file property to common API queries list

### DIFF
--- a/src/helpers/api/queries/list.js
+++ b/src/helpers/api/queries/list.js
@@ -7,7 +7,8 @@ _id,
  size,
  category,
  approved,
- thumbnail`
+ thumbnail,
+ file`
 
 const models = `
  ${common},


### PR DESCRIPTION
Hi there, 

Was working on an implementation where I fetch the full list of models / materials / HDRIs and need the file (direct link), but rather than doing a new query  just for that property I thought it could be included in the common list. Thoughts? :+1: 