### PR TITLE
fix: sort by createdAt when order is Last Added

### DIFF
--- a/src/helpers/store/utils.js
+++ b/src/helpers/store/utils.js
@@ -5,7 +5,7 @@ export const sortAssets = (order, currentAssets) => {
   }
   if (order === 'added') {
     assetsToReturn = currentAssets.sort(
-      (a, b) => new Date(b.lastModified) - new Date(a.lastModified)
+      (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
     )
   }
   if (order === 'size') {


### PR DESCRIPTION
`lastModified` or `updatedAt` aren't attributes in Supabase from what I've tested.

A small note is that `createdAt` isn't a timestamp, so the models with the same date are sorted differently sometimes, depending on the order returned by the database.