### PR TITLE
fix: leva select color

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -15,6 +15,9 @@
     margin: 0;
     padding: 0;
   }
+  select {
+    color: initial;
+  }
 }
 
 a {


### PR DESCRIPTION
resolves #28 

tailwind base styles was messing with leva, so I changed the select color from `inherit` to `initial`